### PR TITLE
Ignoring plz-out for docker, should speed up local docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 # Ignore files not build in docker image
 plz-out
+
+# Ignore git directories
+.git
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Ignore files not build in docker image
+plz-out


### PR DESCRIPTION
The binaries created inside docker are likely to be different to local development, so just make the docker build slower than required.