### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -1,8 +1,6 @@
 # golang:1.13.1-alpine3.10
 FROM golang@sha256:2293e952c79b8b3a987e1e09d48b6aa403d703cef9a8fa316d30ba2918d37367 as builder
 
-EXPOSE 9090
-
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 RUN apk add --no-cache curl wget gcc make bash git musl-dev libc6-compat
@@ -21,6 +19,8 @@ RUN source ~/.profile && plz build //:prometheus-cardinality-exporter --show_all
 
 # alpine:3.10.3
 FROM alpine@sha256:c19173c5ada610a5989151111163d28a67368362762534d8a8121ce95cf2bd5a
+
+EXPOSE 9090
 
 COPY --from=builder /go/github.com/thought-machine/prometheus-cardinality-exporter/plz-out/bin/prometheus-cardinality-exporter /home/app/prometheus-cardinality-exporter
 

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -34,13 +34,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: 9090
+              port: http
             initialDelaySeconds: 5
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /health
-              port: 9090
+              port: http
             initialDelaySeconds: 5
             periodSeconds: 3
           resources:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -31,6 +31,12 @@ spec:
           ports:
             - containerPort: 9090
               name: http
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 3
           resources:
             requests:
               memory: 100Mi

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -37,6 +37,12 @@ spec:
               port: 9090
             initialDelaySeconds: 5
             periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 3
           resources:
             requests:
               memory: 100Mi

--- a/main.go
+++ b/main.go
@@ -12,10 +12,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	"github.com/thought-machine/prometheus-cardinality-exporter/cardinality"
 	"github.com/cenkalti/backoff"
 	"github.com/jessevdk/go-flags"
 	logging "github.com/sirupsen/logrus"
+	"github.com/thought-machine/prometheus-cardinality-exporter/cardinality"
 )
 
 var log = logging.WithFields(logging.Fields{})
@@ -205,6 +205,9 @@ func main() {
 	log.Infof("Serving on port: %d", opts.Port)
 	log.Infof("Serving Prometheus metrics on /metrics")
 	http.Handle("/metrics", promhttp.Handler())
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "OK")
+	})
 
 	log.Infof("Starting Prometheus cardinality metric collection.")
 	go collectMetrics()


### PR DESCRIPTION
When looking for a proper healthcheck for this service, using /metrics is inconvenient as we would need to scrape the metrics all the time which is more expensive both in processing and data transferred and in general slow. Having a separate /health endpoint should be better.