### PR TITLE
Upgrade base container image to Alpine 3.10.9

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -17,8 +17,8 @@ RUN source ~/.profile && plz test //... --show_all_output
 
 RUN source ~/.profile && plz build //:prometheus-cardinality-exporter --show_all_output
 
-# alpine:3.10.3
-FROM alpine@sha256:c19173c5ada610a5989151111163d28a67368362762534d8a8121ce95cf2bd5a
+# alpine:3.10.9
+FROM alpine@sha256:e515aad2ed234a5072c4d2ef86a1cb77d5bfe4b11aa865d9214875734c4eeb3c
 
 EXPOSE 9090
 

--- a/Dockerfile-prometheus-cardinality-exporter
+++ b/Dockerfile-prometheus-cardinality-exporter
@@ -1,5 +1,5 @@
-# digest for alpine:3.10.2
-FROM alpine@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb
+# digest for alpine:3.10.9
+FROM alpine@sha256:e515aad2ed234a5072c4d2ef86a1cb77d5bfe4b11aa865d9214875734c4eeb3c
 
 # Max user
 RUN addgroup -g 255999 -S app && \


### PR DESCRIPTION
Alpine 3.10.8 and below are vulnerable to [CVE-2021-30139](https://nvd.nist.gov/vuln/detail/CVE-2021-30139), which causes `prometheus-cardinality-exporter` to be flagged in container vulnerability scans. Upgrade the base image to Alpine 3.10.9, which contains a version of `apk-tools` (2.10.6) that remediates CVE-2021-30139:

```
$ docker run -it --entrypoint sh hub.docker.com/prometheus-cardinality-exporter:cdf903e0c5f89e2a69ba4c7d58720407d6106c63e476575cd6a29a9656d4eeed
/ $ apk --version
apk-tools 2.10.6, compiled for x86_64.
```