### PR TITLE
Added functionality to deal with auth'd Prometheus instances (closes #14)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,7 @@ go_binary(
         "//third_party/go:logrus",
         "//third_party/go:backoff",
         "//third_party/go:go-flags",
+        "//third_party/go:yaml.v3",
     ],
 )
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Some Prometheus instances will not let the exporter access the ```/api/v1/status
     - Use the ```--auth``` flag to specify a YAML file mapping instance identifiers to the values required.
     - Identifiers can be at the namespace level, the Prometheus instance level, or the sharded instance level. 
     - The naming convention is: ```<namespace>[_<prometheus-instance-name>[_<sharded-instance-name>]]``` (square brackets means optional). 
-    - Examples:
+    - Examples (k8s/secret.yaml provides an example Kubernetes Secret):
         - ```my-namespace: "Bearer 123456789"``` - specifies that requests to Prometheus instances in namespace "my-namespace" should include the header "Authorization: Bearer 123456789".
         - ```my-namespace_my-prometheus-instance: "Basic 123456789"``` - specifies that requests to the Prometheus instance "my-prometheus-instance" in namespace "my-namespace" should include the header "Authorization: Basic 123456789".
         - ```my-namespace_my-prometheus-instance_my-sharded-instance: "Basic 987654321"``` - specifies that requests to sharded instance "my-sharded-instance" with the Prometheus instance name "my-prometheus-instance" in namespace "my-namespace" should include the header "Authorization: Basic 987654321".

--- a/README.md
+++ b/README.md
@@ -33,17 +33,16 @@ There are 4 types of metric exposed:
 | -f        | --freq             | Frequency in hours with which to query the Prometheus API                            |
 | -r        | --regex            | If any found services don’t match the regex, they are ignored                        |
 | -a        | --auth             | Location of YAML file where Prometheus instance authorisation credentials can be found. For instances that don't appear in the file, it is assumed that no authorisation is required to access them. |
-|           | --default_auth     | Default value of the 'Authorization' header when querying the Prometheus API. Leave blank for no default. |
 
 ## Exposing Metrics
 
 ### Dealing with auth'd Prometheus instances
 Some Prometheus instances will not let the exporter access the ```/api/v1/status/tsdb``` endpoint without providing some authorisation credentials. To access these instances, you must provide the authorisation credentials required. The solution to this depends on whether you are using the ```--proms``` or ```--service_discovery``` flag:
 - With ```--proms```: 
-    - Use the ```--default_auth``` flag to specify the default Authorization header value and the ```--auth``` flag to specify a YAML file mapping ```--proms``` instances to the values required.
+    - Use the ```--auth``` flag to specify a YAML file mapping ```--proms``` instances to the values required.
     - Example: \<my-prometheus\>:\<my-Authorization-header-value\>).
 - With ```--service_discovery```: 
-    - Use the ```--default_auth``` flag to specify the default Authorization header value and the ```--auth``` flag to specify a YAML file mapping instance identifiers to the values required. 
+    - Use the ```--auth``` flag to specify a YAML file mapping instance identifiers to the values required.
     - Identifiers can be at the namespace level, the Prometheus instance level, or the sharded instance level. 
     - The naming convention is: \<namespace\>\[\_\<prometheus-instance-name\>\[\_\<sharded-instance-name\>\]\] (square brackets means optional). 
     - Example: my-namespace_my-prometheus-instance: "Basic 123456789". 
@@ -51,7 +50,6 @@ Some Prometheus instances will not let the exporter access the ```/api/v1/status
         1. sharded instance level
         1. Prometheus instance level
         1. namespace level
-        1. ```--default_auth``` value
         1. nothing
 
 In both cases you must specify the exact value of the Authorization header, since the request to ```/api/v1/status/tsdb``` will include the header: ```Authorization: <your-provided-value>```. k8s/configmap.yaml provides an example of the ```--service_discovery``` ```--auth``` file.
@@ -69,7 +67,7 @@ See  https://hub.docker.com/r/thoughtmachine/prometheus-cardinality-exporter
 #### In order to deploy to a kubernetes cluster, run:
 ```plz run //k8s:k8s_push```
 #### Make sure you alter the k8s/deployment.yaml such that it contains the options that you require:
-```args: ["-c", "/home/app/prometheus-cardinality-exporter  --auth=<prometheus-api-auth-values-filepath> --default_auth=<default-prometheus-api-auth-value> --port=<port-to-serve-on> --service_discovery --freq=<frequency-to-ping-api> --selector=<service-selector> --regex=<regex-for-prometheus-instances> --namespaces=<namespace-of-prometheus-instances> [--namespaces=<namespace-of-prometheus-instances>...]]```
+```args: ["-c", "/home/app/prometheus-cardinality-exporter  --auth=<prometheus-api-auth-values-filepath> --port=<port-to-serve-on> --service_discovery --freq=<frequency-to-ping-api> --selector=<service-selector> --regex=<regex-for-prometheus-instances> --namespaces=<namespace-of-prometheus-instances> [--namespaces=<namespace-of-prometheus-instances>...]]```
 
 ## Building
 ```plz build //...```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Some Prometheus instances will not let the exporter access the ```/api/v1/status
 - With ```--service_discovery```: 
     - Use the ```--auth``` flag to specify a YAML file mapping instance identifiers to the values required.
     - Identifiers can be at the namespace level, the Prometheus instance level, or the sharded instance level. 
-    - The naming convention is: ```\<namespace\>\[\_\<prometheus-instance-name\>\[\_\<sharded-instance-name\>\]\]``` (square brackets means optional). 
+    - The naming convention is: ```<namespace>[_<prometheus-instance-name>[_<sharded-instance-name>]]``` (square brackets means optional). 
     - Examples:
         - ```my-namespace: "Bearer 123456789"``` - specifies that requests to Prometheus instances in namespace "my-namespace" should include the header "Authorization: Bearer 123456789".
         - ```my-namespace_my-prometheus-instance: "Basic 123456789"``` - specifies that requests to the Prometheus instance "my-prometheus-instance" in namespace "my-namespace" should include the header "Authorization: Basic 123456789".

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Some Prometheus instances will not let the exporter access the ```/api/v1/status
         1. namespace level
         1. nothing
 
-In both cases you must specify the exact value of the Authorization header, since the request to ```/api/v1/status/tsdb``` will include the header: ```Authorization: <your-provided-value>```. k8s/configmap.yaml provides an example of the ```--service_discovery``` ```--auth``` file.
+In both cases you must specify the exact value of the Authorization header, since the request to ```/api/v1/status/tsdb``` will include the header: ```Authorization: <your-provided-value>```. k8s/secret.yaml provides an example of the ```--service_discovery``` ```--auth``` file.
 
 ### Installing on a cluster
 See k8s/README.md for running on kubernetes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prometheus Cardinality Exporter
 
-A simple Prometheus exporter for exposing the cadinality of metrics Prometheus has scraped.
+A simple Prometheus exporter for exposing the cardinality of metrics Prometheus has scraped.
 
 This was originally started as an intern project by [Harry Fallows](https://github.com/harryfallows) during his internship at [Thought Machine](https://thoughtmachine.net/).
 
@@ -32,15 +32,31 @@ There are 4 types of metric exposed:
 | -p        | --port             | Port on which to serve metrics                                                       |
 | -f        | --freq             | Frequency in hours with which to query the Prometheus API                            |
 | -r        | --regex            | If any found services don’t match the regex, they are ignored                        |
+| -a        | --auth             | Location of YAML file where Prometheus instance authorisation credentials can be found. For instances that don't appear in the file, it is assumed that no authorisation is required to access them. |
+|           | --default_auth     | Default value of the 'Authorization' header when querying the Prometheus API. Leave blank for no default. |
 
 ## Exposing Metrics
+
+### Dealing with Promeheus instances protected by authorisation
+Some Prometheus instances will not let the exporter access the ```/api/v1/status/tsdb``` endpoint without providing some authorisation credentials. To access these instances, you must provide the authorisation credentials required. The solution to this depends on whether you are using the ```--proms``` or ```--service_discovery``` flag:
+- With ```--proms```: use the ```--default_auth``` flag to specify the default Authorization header value and use the ```--auth``` flag to specify a YAML file mapping ```--proms``` instances to the values required (e.g. <my-prometheus>:<my-Authorization-header-value>)
+- With ```--service_discovery```: 
+	- Use the ```--default_auth``` flag to specify the default Authorization header value and use the ```--auth``` to specify a YAML file mapping instance identifiers to the values required. 
+	- Identifiers can be at the namespace level, the prometheus instance level, or the sharded instance level. 
+	- The naming convention is: <namespace>[_<prometheus-instance-name>[_<sharded-instance-name>]] (square brackets means optional). 
+	- Example: my-namespace_my-prometheus-instance: "Basic 123456789". 
+	- When looking for authorisation credentials, the exporter with look in this order:
+		1. sharded instance level
+		2. prometheus instance level
+		3. namespace level
+		4. ```--default_auth``` value
+		5. nothing
 
 ### Installing on a cluster
 See k8s/README.md for running on kubernetes
 
 Docker images are available at thoughtmachine/prometheus-cardinality-exporter:$COMMIT
 See  https://hub.docker.com/r/thoughtmachine/prometheus-cardinality-exporter
-
 
 ### Running Locally
 ```plz run //:prometheus-cardinality-exporter -- --port=<port-to-serve-on> --proms=<prometheus-instance-to-expose> [--proms=<prometheus-instance-to-expose>...] --freq=<frequency-to-ping-api>```
@@ -49,7 +65,7 @@ See  https://hub.docker.com/r/thoughtmachine/prometheus-cardinality-exporter
 #### In order to deploy to a kubernetes cluster, run:
 ```plz run //k8s:k8s_push```
 #### Make sure you alter the k8s/deployment.yaml such that it contains the options that you require:
-```args: ["-c", "/home/app/prometheus-cardinality-exporter  --port=<port-to-serve-on> --service_discovery --freq=<frequency-to-ping-api> --selector=<service-selector> --regex=<regex-for-prometheus-instances> --namespaces=<namespace-of-prometheus-instances> [--namespaces=<namespace-of-prometheus-instances>...]]```
+```args: ["-c", "/home/app/prometheus-cardinality-exporter  --auth=<prometheus-api-auth-values-filepath> --default_auth=<default-prometheus-api-auth-value> --port=<port-to-serve-on> --service_discovery --freq=<frequency-to-ping-api> --selector=<service-selector> --regex=<regex-for-prometheus-instances> --namespaces=<namespace-of-prometheus-instances> [--namespaces=<namespace-of-prometheus-instances>...]]```
 
 ## Building
 ```plz build //...```

--- a/cardinality/cardinality.go
+++ b/cardinality/cardinality.go
@@ -94,7 +94,7 @@ func (promInstance *PrometheusCardinalityInstance) FetchTSDBStatus(prometheusCli
 	defer res.Body.Close()
 
 	if res.StatusCode == 401 {
-		return fmt.Errorf("401 Unauthorized. The provided Authorization value (%s) is incorrect.", promInstance.AuthValue)
+		return fmt.Errorf("401 Unauthorized. The provided Authorization value is incorrect.")
 	}
 
 	// Read the body of the response

--- a/cardinality/cardinality.go
+++ b/cardinality/cardinality.go
@@ -66,6 +66,7 @@ type PrometheusCardinalityInstance struct {
 	InstanceName        string
 	InstanceAddress     string
 	ShardedInstanceName string
+	AuthValue           string
 	LatestTSDBStatus    TSDBStatus
 	TrackedLabels       TrackedLabelNames
 }
@@ -76,6 +77,11 @@ func (promInstance *PrometheusCardinalityInstance) FetchTSDBStatus(prometheusCli
 	// Create a GET request to the Prometheus API
 	apiURL := promInstance.InstanceAddress + "/api/v1/status/tsdb"
 	request, err := http.NewRequest("GET", apiURL, nil)
+
+	if promInstance.AuthValue != "" {
+		request.Header.Add("Authorization", promInstance.AuthValue)
+	}
+
 	if err != nil {
 		return fmt.Errorf("Cannot create GET request to %v: %v", apiURL, err)
 	}
@@ -86,6 +92,10 @@ func (promInstance *PrometheusCardinalityInstance) FetchTSDBStatus(prometheusCli
 		return fmt.Errorf("Can't connect to %v: %v ", apiURL, err)
 	}
 	defer res.Body.Close()
+
+	if res.StatusCode == 401 {
+		return fmt.Errorf("401 Unauthorized. The provided Authorization value (%s) is incorrect.", promInstance.AuthValue)
+	}
 
 	// Read the body of the response
 	body, err := ioutil.ReadAll(res.Body)

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -10,5 +10,5 @@ Defines the service account for the service.
 States the resources that service discovery is allowed to query (namespaces, endpoints) and with what method (list).
 ## ```clusterrolesbinding.yaml```
 Binds the cluster role to the service account.
-## ```configmap.yaml```
-Stores the configuration files necessary to run the exporter. Currently only one config file is (possibly) required; this is the YAML file specified by the ```--auth``` flag.
+## ```secret.yaml```
+Stores the configuration files necessary to run the exporter. Currently only one secret file is (possibly) required; this is the YAML file specified by the ```--auth``` flag.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -10,3 +10,5 @@ Defines the service account for the service.
 States the resources that service discovery is allowed to query (namespaces, endpoints) and with what method (list).
 ## ```clusterrolesbinding.yaml```
 Binds the cluster role to the service account.
+## ```configmap.yaml```
+Stores the configuration files necessary to run the exporter. Currently only one config file is (possibly) required; this is the YAML file specified by the ```--auth``` flag.

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-cardinality-exporter-config-map
+  namespace: example-namespace
+data:
+  prometheus-api-auth-values.yaml: |
+    example-namespace_example-prometheus-instance_example-sharded-instance: "Basic YWRtaW46cGFzc3dvcmQ="

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: prometheus-cardinality-exporter-config-map
-  namespace: example-namespace
-data:
-  prometheus-api-auth-values.yaml: |
-    example-namespace_example-prometheus-instance_example-sharded-instance: "Basic YWRtaW46cGFzc3dvcmQ="

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -27,7 +27,10 @@ spec:
         - name: prometheus-cardinality-exporter
           image: //:prometheus-cardinality-exporter_alpine
           command: ["/bin/sh"]
-          args: ["-c", "/home/app/prometheus-cardinality-exporter --service_discovery --freq=2 --selector=app=prometheus --regex=prometheus-[a-zA-Z0-9_-]+ --namespaces=monitoring"]
+          args: ["-c", "/home/app/prometheus-cardinality-exporter --auth=/etc/prometheus-cardinality-exporter/auth/prometheus-api-auth-values.yaml --default_auth=\"Basic YWRtaW46cGFzc3dvcmQ=\" --service_discovery --freq=2 --selector=app=prometheus --regex=prometheus[a-zA-Z0-9_-]*"]
+          volumeMounts:
+          - mountPath: /etc/prometheus-cardinality-exporter/auth
+            name: auth
           ports:
             - containerPort: 9090
               name: http
@@ -49,5 +52,13 @@ spec:
               cpu: 100m
             limits:
               memory: 700Mi
+      volumes:
+      - name: auth
+        configMap:
+          defaultMode: 420
+          name: prometheus-cardinality-exporter-config-map
+          items:
+          - key: prometheus-api-auth-values.yaml
+            path: prometheus-api-auth-values.yaml
       securityContext:
         runAsUser: 1000

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: prometheus-cardinality-exporter
           image: //:prometheus-cardinality-exporter_alpine
           command: ["/bin/sh"]
-          args: ["-c", "/home/app/prometheus-cardinality-exporter --auth=/etc/prometheus-cardinality-exporter/auth/prometheus-api-auth-values.yaml --default_auth=\"Basic YWRtaW46cGFzc3dvcmQ=\" --service_discovery --freq=2 --selector=app=prometheus --regex=prometheus[a-zA-Z0-9_-]*"]
+          args: ["-c", "/home/app/prometheus-cardinality-exporter --auth=/etc/prometheus-cardinality-exporter/auth/prometheus-api-auth-values.yaml --service_discovery --freq=2 --selector=app=prometheus --regex=prometheus[a-zA-Z0-9_-]*"]
           volumeMounts:
           - mountPath: /etc/prometheus-cardinality-exporter/auth
             name: auth

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -54,9 +54,9 @@ spec:
               memory: 700Mi
       volumes:
       - name: auth
-        configMap:
+        secret:
           defaultMode: 420
-          name: prometheus-cardinality-exporter-config-map
+          secretName: prometheus-cardinality-exporter-secret
           items:
           - key: prometheus-api-auth-values.yaml
             path: prometheus-api-auth-values.yaml

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prometheus-cardinality-exporter-secret
+  namespace: example-namespace
+stringData:
+  prometheus-api-auth-values.yaml: |
+    example-namespace_example-prometheus-instance_example-sharded-instance: "Basic YWRtaW46cGFzc3dvcmQ=" # set Authorization header for specific sharded instance
+    example-namespace_example-prometheus-instance: "Bearer 123456789" # set Authorization header for all sharded instances that have the Prometheus instance name "example-prometheus-instance" in namespace "example-namespace"
+    example-namespace: "Basic 123456789" # set Authorization header for all instances in namespace "example-namespace"

--- a/main.go
+++ b/main.go
@@ -24,15 +24,14 @@ import (
 var log = logging.WithFields(logging.Fields{})
 
 var opts struct {
-	Selector                string   `long:"selector" short:"s" default:"app=prometheus" help:"Selector for Service Discovery."`
-	Namespaces              []string `long:"namespaces" short:"n"  help:"Namespaces for Service Discovery."`
-	PrometheusInstances     []string `long:"proms" short:"i" help:"Prometheus instance links. Mutually exclusive to the service discover flag."`
-	PromAPIAuthValuesFile   string   `long:"auth" short:"a" help:"Location of YAML file where Prometheus instance authorisation credentials can be found. For instances that don't appear in the file, it is assumed that no authorisation is required to access them."`
-	DefaultPromAPIAuthValue string   `long:"default_auth" help:"Default value of the 'Authorization' header when querying the Prometheus API. Leave blank for no default."`
-	ServiceDiscovery        bool     `long:"service_discovery" short:"d" help:"Service discovery flag, use service discovery to find new instances of Prometheus within a cluster. Mutually exclusive to the prometheus instance link flag."`
-	Port                    int      `long:"port" short:"p" default:"9090" help:"Port on which to serve."`
-	Frequency               float32  `long:"freq" short:"f" default:"6" help:"Frequency in hours with which to query the Prometheus API."`
-	ServiceRegex            string   `long:"regex" short:"r" default:"prometheus-[a-zA-Z0-9_-]+" help:"If any found services don't match the regex, they are ignored."`
+	Selector              string   `long:"selector" short:"s" default:"app=prometheus" help:"Selector for Service Discovery."`
+	Namespaces            []string `long:"namespaces" short:"n"  help:"Namespaces for Service Discovery."`
+	PrometheusInstances   []string `long:"proms" short:"i" help:"Prometheus instance links. Mutually exclusive to the service discover flag."`
+	PromAPIAuthValuesFile string   `long:"auth" short:"a" help:"Location of YAML file where Prometheus instance authorisation credentials can be found. For instances that don't appear in the file, it is assumed that no authorisation is required to access them."`
+	ServiceDiscovery      bool     `long:"service_discovery" short:"d" help:"Service discovery flag, use service discovery to find new instances of Prometheus within a cluster. Mutually exclusive to the prometheus instance link flag."`
+	Port                  int      `long:"port" short:"p" default:"9090" help:"Port on which to serve."`
+	Frequency             float32  `long:"freq" short:"f" default:"6" help:"Frequency in hours with which to query the Prometheus API."`
+	ServiceRegex          string   `long:"regex" short:"r" default:"prometheus-[a-zA-Z0-9_-]+" help:"If any found services don't match the regex, they are ignored."`
 }
 
 func collectMetrics() {
@@ -152,8 +151,6 @@ func collectMetrics() {
 								cardinalityInfoByInstance[instanceID].AuthValue = authValue
 							} else if authValue, ok := promAPIAuthValues[namespace]; ok { // Check for Prometheus API credentials for namespace
 								cardinalityInfoByInstance[instanceID].AuthValue = authValue
-							} else { // Set auth value to the default (might be "")
-								cardinalityInfoByInstance[instanceID].AuthValue = opts.DefaultPromAPIAuthValue
 							}
 						}
 					}
@@ -193,11 +190,6 @@ func collectMetrics() {
 						SeriesCountByLabelValuePairLabels: [10]string{},
 					},
 				}
-
-				if cardinalityInfoByInstance[instanceID].AuthValue == "" {
-					cardinalityInfoByInstance[instanceID].AuthValue = opts.DefaultPromAPIAuthValue
-				}
-
 			}
 		}
 


### PR DESCRIPTION
This PR offers a solution to issue #14
- A YAML file and/or default value can be specified in flags to be included as the "Authorization" header value when pinging the Prometheus API for cardinality metrics
- Test using `plz test //...` from the root of the repo
- Test in a Kubernetes cluster by deploying with ---service_discovery (where an auth'd Prometheus is discoverable) or --proms (with an auth's Prometheus instance); requires a ConfigMap (see k8s/configmap.yaml) for the Auth values and changes to the deployment to include it