### PR TITLE
Fix metrics deletion

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/yaml.v3"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 

--- a/main.go
+++ b/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/jessevdk/go-flags"
-	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
@@ -12,12 +10,14 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"gopkg.in/yaml.v3"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	"github.com/cenkalti/backoff"
+	"github.com/jessevdk/go-flags"
 	logging "github.com/sirupsen/logrus"
 	"github.com/thought-machine/prometheus-cardinality-exporter/cardinality"
 )

--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"github.com/jessevdk/go-flags"
+	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
@@ -11,6 +13,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 


### PR DESCRIPTION
Hey there, we've integrated this service the company im working in. and we've noticed that once head stats cease to contain some record the service should delete the exported metric from its registry but it doesnt. this is due the misplace of the infinite for-loop which does all the init steps ,that should happen once, multiple times causing the `trackedLabels` field to be override each step hence loosing the trackedLabels from previous iterations.

i placed the for loop in its right place and tested it and it fixes the issue