### PR TITLE
Configure the amount of statistics to fetch from Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ There are 4 types of metric exposed:
 | -r        | --regex            | If any found services don’t match the regex, they are ignored                        |
 | -a        | --auth             | Location of YAML file where Prometheus instance authorisation credentials can be found. For instances that don't appear in the file, it is assumed that no authorisation is required to access them. |
 | -l        | --log.level        | Level for logging. Options (in order of verbosity): [debug, info, warn, error, fatal].|
+| -L        | --stats-limit      | Limit the number of items fetched from the TSDB statistics. (default: 10).            |
 
 ## Exposing Metrics
 

--- a/cardinality/cardinality.go
+++ b/cardinality/cardinality.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -73,10 +74,15 @@ type PrometheusCardinalityInstance struct {
 }
 
 // FetchTSDBStatus saves tracked TSDB status metrics in the struct pointed to by the "data" parameter
-func (promInstance *PrometheusCardinalityInstance) FetchTSDBStatus(prometheusClient PrometheusClient) error {
+func (promInstance *PrometheusCardinalityInstance) FetchTSDBStatus(prometheusClient PrometheusClient, statsLimit int) error {
 
 	// Create a GET request to the Prometheus API
-	apiURL := promInstance.InstanceAddress + "/api/v1/status/tsdb"
+	values := url.Values{}
+	values.Add("limit", fmt.Sprintf("%d", statsLimit))
+	queryParams := values.Encode()
+
+	apiURL := promInstance.InstanceAddress + "/api/v1/status/tsdb?" + queryParams
+
 	request, err := http.NewRequest("GET", apiURL, nil)
 
 	if promInstance.AuthValue != "" {

--- a/cardinality/cardinality_test.go
+++ b/cardinality/cardinality_test.go
@@ -88,7 +88,7 @@ func (ts *CardinalitySuite) TestFetchTSDBStatus() {
 			Body:       io.NopCloser(bytes.NewBufferString(tt.json)),
 		}
 		ts.MockPrometheusClient.EXPECT().Do(AuthHeaderCorrect(tt.expectedAuthHeaderValue)).Return(response, nil)
-		err := tt.prometheusInstance.FetchTSDBStatus(ts.MockPrometheusClient)
+		err := tt.prometheusInstance.FetchTSDBStatus(ts.MockPrometheusClient, 20)
 
 		assert.Equal(ts.T(), tt.incomingTSDBStatus, tt.prometheusInstance.LatestTSDBStatus)
 		assert.Equal(ts.T(), err, nil)
@@ -205,7 +205,7 @@ func (ts *CardinalitySuite) TestE2E() {
 		// Fetch metrics from test API
 		tt.prometheusInstance.LatestTSDBStatus = *new(TSDBStatus)
 		tt.prometheusInstance.InstanceAddress = fmt.Sprintf("http://localhost:%v", mockAPIPort)
-		err = tt.prometheusInstance.FetchTSDBStatus(&http.Client{})
+		err = tt.prometheusInstance.FetchTSDBStatus(&http.Client{}, 20)
 		if err != nil {
 			log.WithError(err).Warningf("Error fetching Prometheus status: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ var opts struct {
 	Frequency             float32  `long:"freq" short:"f" default:"6" help:"Frequency in hours with which to query the Prometheus API."`
 	ServiceRegex          string   `long:"regex" short:"r" default:"prometheus-[a-zA-Z0-9_-]+" help:"If any found services don't match the regex, they are ignored."`
 	LogLevel              string   `long:"log.level" short:"l" default:"info" help:"Level for logging. Options (in order of verbosity): [debug, info, warn, error, fatal]."`
+	StatsLimit            int      `long:"stats-limit" short:"L" default:"10" help:"Limit the number of items fetched from the TSDB statistics."`
 }
 
 func collectMetrics() {
@@ -214,7 +215,7 @@ func collectMetrics() {
 
 			// Fetch the data from Prometheus
 			err := backoff.Retry(func() error {
-				return cardinalityInfoByInstance[instanceID].FetchTSDBStatus(prometheusClient)
+				return cardinalityInfoByInstance[instanceID].FetchTSDBStatus(prometheusClient, opts.StatsLimit)
 			}, backoff.WithMaxRetries(backoff.NewExponentialBackOff(), numRetries))
 			if err != nil {
 				log.WithError(err).Warningf("Error fetching Prometheus status: %v", err)


### PR DESCRIPTION
By default, [Prometheus returns only 10 items](https://prometheus.io/docs/prometheus/latest/querying/api/#tsdb-stats), but I wanted to be able to get more insights out of this endpoint.

![image](https://github.com/user-attachments/assets/c5e65dfc-9400-4613-8ce6-1a9b95f6a394)
