### PR TITLE
[INFRA-96833] Go version upgrade to fix security vulnerabilities

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -1,5 +1,5 @@
-# 1.23.5-alpine3.21 (linux/amd64)
-FROM golang@sha256:53443fdc64453f971b5c82374d86945b90c053880131b13ee50704001e77f23a as builder
+# 1.23.6-alpine3.21 (linux/amd64)
+FROM golang@sha256:c68fb23e94573004a99d7c5eab2dbaefeb81f56f13180568911e45cfc5b458c7 as builder
 
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go
 
@@ -17,8 +17,8 @@ RUN go test ./... -race
 # env var and flags ensure a static binary
 RUN CGO_ENABLED=0 go build -ldflags="-extldflags=-static" .
 
-# alpine:3.21.1 (linux/amd64)
-FROM alpine@sha256:f3a728d5dcf0f45691478201526b30230de3a3e3b26ffe92462d0a98fcb8f4e5
+# alpine:3.21.2 (linux/amd64)
+FROM alpine@sha256:483f502c0e6aff6d80a807f25d3f88afa40439c29fdd2d21a0912e0f42db842a
 
 EXPOSE 9090
 

--- a/Dockerfile-builder_distroless
+++ b/Dockerfile-builder_distroless
@@ -1,5 +1,5 @@
-# 1.23.5-alpine3.21 (linux/amd64)
-FROM golang@sha256:53443fdc64453f971b5c82374d86945b90c053880131b13ee50704001e77f23a as builder
+# 1.23.6-alpine3.21 (linux/amd64)
+FROM golang@sha256:c68fb23e94573004a99d7c5eab2dbaefeb81f56f13180568911e45cfc5b458c7 as builder
 
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github/thought-machine/prometheus-cardinality-exporter
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible


### PR DESCRIPTION
Updated Go version to fix security vulnerabilities:

https://nvd.nist.gov/vuln/detail/CVE-2025-22866

Alpine image: https://hub.docker.com/layers/library/alpine/3.21.2/images/sha256-483f502c0e6aff6d80a807f25d3f88afa40439c29fdd2d21a0912e0f42db842a

Golang image: https://hub.docker.com/layers/library/golang/1.23.6-alpine3.21/images/sha256-c68fb23e94573004a99d7c5eab2dbaefeb81f56f13180568911e45cfc5b458c7

Local vuln scan on the updated image:
```
elnur@elnur-tm04154:~/Desktop/prometheus-cardinality-exporter$ plz run //third_party/binary:trivy -- image prom-card-exporter:latest
13:53:23.339 WARNING: Using default repo at /home/elnur/core3/src
2025-02-12T13:53:23Z	INFO	Vulnerability scanning is enabled
2025-02-12T13:53:23Z	INFO	Secret scanning is enabled
2025-02-12T13:53:23Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-02-12T13:53:23Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.53/docs/scanner/secret#recommendation for faster secret detection
2025-02-12T13:53:24Z	INFO	Number of language-specific files	num=1
2025-02-12T13:53:24Z	INFO	[gobinary] Detecting vulnerabilities...
```

Local testing:
```
docker build -f Dockerfile-builder_distroless -t prom-card-exporter:latest .
docker run --network=host prom-card-exporter:latest --port=9090 --proms=http://192.168.39.42:31102 -l=debug
```

Results:
```
{
  "status": "success",
  "data": {
    "headStats": {
      "numSeries": 75296,
      "numLabelPairs": 7459,
      "chunkCount": 152538,
      "minTime": 1739365893674,
      "maxTime": 1739368928675
    },
    "seriesCountByMetricName": [
      {
        "name": "grpc_server_handled_total",
        "value": 8738
      },
      {
        "name": "kafka_log_log_logendoffset",
        "value": 2322
      },
      {
        "name": "kafka_log_log_size",
        "value": 2322
      },
      {
        "name": "kafka_cluster_partition_replicascount",
        "value": 2322
      },
      {
        "name": "kafka_log_log_logstartoffset",
        "value": 2322
      },
      {
        "name": "kafka_cluster_partition_underreplicated",
        "value": 2322
      },
      {
        "name": "kafka_cluster_partition_insyncreplicascount",
        "value": 2322
      },
      {
        "name": "kafka_cluster_partition_atminisr",
        "value": 2322
      },
      {
        "name": "kafka_cluster_partition_laststableoffsetlag",
        "value": 2322
      },
      {
        "name": "kafka_cluster_partition_underminisr",
        "value": 2322
      }
    ],
    "labelValueCountByLabelName": [
      {
        "name": "__name__",
        "value": 1532
      },
      {
        "name": "mountpoint",
        "value": 1013
      },
      {
        "name": "topic",
        "value": 492
      },
      {
        "name": "grpc_method",
        "value": 370
      },
      {
        "name": "uid",
        "value": 298
      },
      {
        "name": "le",
        "value": 168
      },
      {
        "name": "exported_service",
        "value": 166
      },
      {
        "name": "cluster_ip",
        "value": 158
      },
      {
        "name": "label_app",
        "value": 132
      },
      {
        "name": "pod",
        "value": 129
      }
    ],
    "memoryInBytesByLabelName": [
      {
        "name": "__name__",
        "value": 2545788
      },
      {
        "name": "job",
        "value": 1626204
      },
      {
        "name": "pod",
        "value": 1536281
      },
      {
        "name": "kubernetes_pod",
        "value": 1454450
      },
      {
        "name": "topic",
        "value": 1333113
      },
      {
        "name": "instance",
        "value": 1163123
      },
      {
        "name": "app",
        "value": 1078014
      },
      {
        "name": "kubernetes_name",
        "value": 827400
      },
      {
        "name": "service",
        "value": 753884
      },
      {
        "name": "crown_tmachine_io_package_date",
        "value": 564140
      }
    ],
    "seriesCountByLabelValuePair": [
      {
        "name": "kubernetes_namespace=default",
        "value": 67850
      },
      {
        "name": "namespace=default",
        "value": 67760
      },
      {
        "name": "crown_tmachine_io_package_date=2025-02-10",
        "value": 29997
      },
      {
        "name": "container=main",
        "value": 29176
      },
      {
        "name": "app_kubernetes_io_created_by=crown-operator",
        "value": 29154
      },
      {
        "name": "project=kafka",
        "value": 27262
      },
      {
        "name": "webhooks_tmachine_io_ca_injector=disable",
        "value": 27260
      },
      {
        "name": "app_kubernetes_io_instance=eng-local",
        "value": 27260
      },
      {
        "name": "job=monitoring/strimzi-kafka-cluster",
        "value": 27260
      },
      {
        "name": "strimzi_io_cluster=eng-local",
        "value": 27260
      }
    ]
  }
}

```













