### PR TITLE
Make docker images to be tagged with the release version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,15 +46,11 @@ workflows:
       - build_and_release:
           context: conntest-dockerhub-release
           filters:
-            tags:
-              only: /^v.*/
             branches:
-              only: /.*/
+              only: master
   test-buildable:
     jobs:
       - build_and_test:
           filters:
-            tags:
-              only: /^v.*/
             branches:
-              ignore: /.*/
+              ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,17 +8,18 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: echo "Building latest"
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"latest"
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"latest" --help
+                    TAG = "${CIRCLE_BUILD_NUM}".0.0
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$TAG"
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$TAG" --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"latest"_distroless
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"latest"_distroless --help
+                    TAG = "${CIRCLE_BUILD_NUM}".0.0
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$TAG"_distroless
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$TAG"_distroless --help
   build_and_release:
     working_directory: ~/prometheus-cardinality-exporter
     machine: true
@@ -27,19 +28,22 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"latest"
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"latest" --help
+                    TAG = "${CIRCLE_BUILD_NUM}".0.0
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$TAG"
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$TAG" --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"latest"_distroless
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"latest"_distroless --help
+                    TAG = "${CIRCLE_BUILD_NUM}".0.0
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$TAG"_distroless
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$TAG"_distroless --help
       - run:
           name: Publish Docker Images to Docker Hub
           command: |
+            TAG = "${CIRCLE_BUILD_NUM}".0.0
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push thoughtmachine/prometheus-cardinality-exporter:"latest"
-            docker push thoughtmachine/prometheus-cardinality-exporter:"latest"_distroless
+            docker push thoughtmachine/prometheus-cardinality-exporter:"$TAG"
+            docker push thoughtmachine/prometheus-cardinality-exporter:"$TAG"_distroless
 workflows:
   version: 2
   build-master:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    TAG = "${CIRCLE_BUILD_NUM}".0.0
+                    TAG = 1."${CIRCLE_BUILD_NUM}.0"
                     docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:$TAG
                     docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:$TAG --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    TAG = "${CIRCLE_BUILD_NUM}".0.0
+                   TAG = 1."${CIRCLE_BUILD_NUM}.0"
                     docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless
                     docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless --help
   build_and_release:
@@ -28,19 +28,19 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    TAG = "${CIRCLE_BUILD_NUM}".0.0
+                   TAG = 1."${CIRCLE_BUILD_NUM}.0"
                     docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:$TAG
                     docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:$TAG --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    TAG = "${CIRCLE_BUILD_NUM}".0.0
+                   TAG = 1."${CIRCLE_BUILD_NUM}.0"
                     docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless
                     docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless --help
       - run:
           name: Publish Docker Images to Docker Hub
           command: |
-            TAG = "${CIRCLE_BUILD_NUM}".0.0
+           TAG = 1."${CIRCLE_BUILD_NUM}.0"
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             docker push thoughtmachine/prometheus-cardinality-exporter:$TAG
             docker push thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,11 +46,15 @@ workflows:
       - build_and_release:
           context: conntest-dockerhub-release
           filters:
+            tags:
+              only: /^v.*/
             branches:
               only: master
   test-buildable:
     jobs:
       - build_and_test:
           filters:
+            tags:
+              only: /^v.*/
             branches:
               ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
     machine: true
     steps:
       - checkout
+      - run: echo "Building $CIRCLE_TAG"
       - run:
           name: Build Alpine Docker Image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,14 +12,14 @@ jobs:
           name: Build Alpine Docker Image
           command: |
                     TAG = "${CIRCLE_BUILD_NUM}".0.0
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$TAG"
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$TAG" --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:$TAG
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:$TAG --help
       - run:
           name: Build distroless Docker Image
           command: |
                     TAG = "${CIRCLE_BUILD_NUM}".0.0
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$TAG"_distroless
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$TAG"_distroless --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless --help
   build_and_release:
     working_directory: ~/prometheus-cardinality-exporter
     machine: true
@@ -29,21 +29,21 @@ jobs:
           name: Build Alpine Docker Image
           command: |
                     TAG = "${CIRCLE_BUILD_NUM}".0.0
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$TAG"
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$TAG" --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:$TAG
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:$TAG --help
       - run:
           name: Build distroless Docker Image
           command: |
                     TAG = "${CIRCLE_BUILD_NUM}".0.0
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$TAG"_distroless
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$TAG"_distroless --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless --help
       - run:
           name: Publish Docker Images to Docker Hub
           command: |
             TAG = "${CIRCLE_BUILD_NUM}".0.0
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push thoughtmachine/prometheus-cardinality-exporter:"$TAG"
-            docker push thoughtmachine/prometheus-cardinality-exporter:"$TAG"_distroless
+            docker push thoughtmachine/prometheus-cardinality-exporter:$TAG
+            docker push thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless
 workflows:
   version: 2
   build-master:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,17 +8,17 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: echo "Building $CIRCLE_TAG"
+      - run: echo "Building latest"
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG" --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"latest"
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"latest" --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"_distroless
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"_distroless --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"latest"_distroless
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"latest"_distroless --help
   build_and_release:
     working_directory: ~/prometheus-cardinality-exporter
     machine: true
@@ -27,19 +27,19 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG" --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"latest"
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"latest" --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"_distroless
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"_distroless --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"latest"_distroless
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"latest"_distroless --help
       - run:
           name: Publish Docker Images to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"
-            docker push thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"_distroless
+            docker push thoughtmachine/prometheus-cardinality-exporter:"latest"
+            docker push thoughtmachine/prometheus-cardinality-exporter:"latest"_distroless
 workflows:
   version: 2
   build-master:
@@ -50,7 +50,7 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              only: master
+              only: /.*/
   test-buildable:
     jobs:
       - build_and_test:
@@ -58,4 +58,4 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: master
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,15 +11,13 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    TAG = 1."${CIRCLE_BUILD_NUM}.0"
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:$TAG
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:$TAG --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --help
       - run:
           name: Build distroless Docker Image
           command: |
-                   TAG = 1."${CIRCLE_BUILD_NUM}.0"
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --help
   build_and_release:
     working_directory: ~/prometheus-cardinality-exporter
     machine: true
@@ -28,22 +26,19 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                   TAG = 1."${CIRCLE_BUILD_NUM}.0"
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:$TAG
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:$TAG --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --help
       - run:
           name: Build distroless Docker Image
           command: |
-                   TAG = 1."${CIRCLE_BUILD_NUM}.0"
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --help
       - run:
           name: Publish Docker Images to Docker Hub
           command: |
-           TAG = 1."${CIRCLE_BUILD_NUM}.0"
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push thoughtmachine/prometheus-cardinality-exporter:$TAG
-            docker push thoughtmachine/prometheus-cardinality-exporter:$TAG_distroless
+            docker push thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"
+            docker push thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless
 workflows:
   version: 2
   build-master:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_SHA1"
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_SHA1" --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG" --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_SHA1"_distroless
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_SHA1"_distroless --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"_distroless
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"_distroless --help
   build_and_release:
     working_directory: ~/prometheus-cardinality-exporter
     machine: true
@@ -26,19 +26,19 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_SHA1"
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_SHA1" --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG" --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_SHA1"_distroless
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_SHA1"_distroless --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"_distroless
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"_distroless --help
       - run:
           name: Publish Docker Images to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_SHA1"
-            docker push thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_SHA1"_distroless
+            docker push thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"
+            docker push thoughtmachine/prometheus-cardinality-exporter:"$CIRCLE_TAG"_distroless
 workflows:
   version: 2
   build-master:


### PR DESCRIPTION
Make docker images to be tagged with the build num version instead of  the SHA1 hash of the last commit of the current build. The docker images are https://hub.docker.com/r/thoughtmachine/prometheus-cardinality-exporter/tags

then with every commit tag will increase. there are not that many commits - only when we do go dependency bumps  . there is no active feature work as such .
