### PR TITLE
Add platform to the docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/amd64
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/amd64 . --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/amd64
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/amd64  --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --help
   build_and_release:
     working_directory: ~/prometheus-cardinality-exporter
     machine: true
@@ -26,19 +26,19 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/amd64
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/amd64  --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/amd64
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/amd64  --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --help
       - run:
           name: Publish Docker Images to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"
-            docker push thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless
+            docker push thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/amd64
+            docker push thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/amd64
 workflows:
   version: 2
   build-master:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,12 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"
+                    docker build -f Dockerfile-builder --platform=linux/amd64 . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"
                     docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless
+                    docker build -f Dockerfile-builder_distroless --platform=linux/amd64 . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless
                     docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --help
   build_and_release:
     working_directory: ~/prometheus-cardinality-exporter
@@ -26,19 +26,19 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"
+                    docker build -f Dockerfile-builder --platform=linux/amd64 . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"
                     docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless
+                    docker build -f Dockerfile-builder_distroless --platform=linux/amd64 . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless
                     docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --help
       - run:
           name: Publish Docker Images to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/amd64
-            docker push thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/amd64
+            docker push thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"
+            docker push thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless
 workflows:
   version: 2
   build-master:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64 .
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64
                     docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64 . --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64 .
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64 . --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64  --help
   build_and_release:
     working_directory: ~/prometheus-cardinality-exporter
     machine: true
@@ -26,13 +26,13 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64 .
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64 . --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64  --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64 .
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64 . --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64  --help
       - run:
           name: Publish Docker Images to Docker Hub
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64 . --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/amd64
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/amd64 . --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64  --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/amd64
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/amd64  --help
   build_and_release:
     working_directory: ~/prometheus-cardinality-exporter
     machine: true
@@ -26,13 +26,13 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64  --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/amd64
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/amd64  --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64  --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/amd64
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/amd64  --help
       - run:
           name: Publish Docker Images to Docker Hub
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64 .
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64 . --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64 .
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64 . --help
   build_and_release:
     working_directory: ~/prometheus-cardinality-exporter
     machine: true
@@ -26,13 +26,13 @@ jobs:
       - run:
           name: Build Alpine Docker Image
           command: |
-                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --help
+                    docker build -f Dockerfile-builder . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64 .
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0" --platform=linux/arm64,linux/amd64 . --help
       - run:
           name: Build distroless Docker Image
           command: |
-                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless
-                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --help
+                    docker build -f Dockerfile-builder_distroless . --rm=false -t thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64 .
+                    docker run --rm -it thoughtmachine/prometheus-cardinality-exporter:"1.${CIRCLE_BUILD_NUM}.0"_distroless --platform=linux/arm64,linux/amd64 . --help
       - run:
           name: Publish Docker Images to Docker Hub
           command: |


### PR DESCRIPTION
currently no platform is provided 

```
$ docker manifest inspect  docker.io/thoughtmachine/prometheus-cardinality-exporter:1.155.0_distroless
{
	"schemaVersion": 2,
	"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
	"config": {
		"mediaType": "application/vnd.docker.container.image.v1+json",
		"size": 1101,
		"digest": "sha256:46925f87a198a749e83d138eefc8ceaa634a9135265377b561453f6965a365d7"
	},
	"layers": [
		{
			"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
			"size": 24822150,
			"digest": "sha256:5463ccc088ee9a2d8d0aadae75ce1bcd43dd52026ec9cf3cd62f06d69c2453c9"
		}
	]
}
```