### PR TITLE
update go version to 1.24.6 to mitigate CVE-2025-47907 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github/thought-machine/prometheus-cardinality-exporter
 
-go 1.24.2
+go 1.24.6
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible


### PR DESCRIPTION
Mitigate https://www.cve.org/CVERecord?id=CVE-2025-47907