### PR TITLE
restructure circleci.config to make versioning better

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,6 @@ jobs:
       - run:
           name: "Build and Test Docker Image"
           command: |
-            source $BASH_ENV
-
             docker build -f Dockerfile-builder . -t thoughtmachine/prometheus-cardinality-exporter:latest
             docker run --rm thoughtmachine/prometheus-cardinality-exporter:latest --help
 


### PR DESCRIPTION
Currently circleci config is creating a new docker image( ant thus version) upon every commit which is not ideal. 

The version number depends on circleci build num variable which is not deterministic and does not increase sequentially. For example we have version 1.197.0 and then next commit creates version 1.203.0. This is then used to create a release which in turn also follows inconsistent versioning.

Updating the config to follow best practises should do the following: 
1. Determine and Export Docker Image Tag:
 -Run step contains the core logic.
- It first checks for ${CIRCLE_TAG}. CircleCI only populates this variable when you push a Git tag. If it exists, we use it directly.
- If there's no Git tag, it falls back to creating a tag from the branch name (${CIRCLE_BRANCH}) and the short commit hash (${CIRCLE_SHA1}).
- The sed command sanitizes the branch name to ensure it's a valid Docker tag.
- echo "export DOCKER_TAG=..." >> $BASH_ENV is the standard CircleCI method to make the DOCKER_TAG variable available to all subsequent steps in the same job.
2. Build and Push Docker Image:
- This step uses the ${DOCKER_TAG} variable that was exported in the previous step to tag the image.
- This step pushes the specifically-versioned image.
- It also includes an if block to additionally tag the image as latest only when the build runs on the main branch. This is a common convention, providing a stable endpoint for development environments to pull the most recent main build.

With this setup, the versioning is handled automatically. It's traceable, automated, and distinguishes clearly between development builds and formal releases.
