### PR TITLE
Bump golangci-lint-action to v8

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: '1.26.2'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           # Require: The version of golangci-lint to use.
           version: v2.11.4


### PR DESCRIPTION
Updates golangci-lint-action from v7 to v8 in the linting workflow.